### PR TITLE
Updated the application to user warp, servant

### DIFF
--- a/core/app/Main.hs
+++ b/core/app/Main.hs
@@ -1,18 +1,28 @@
+{-# LANGUAGE DataKinds, TypeOperators, ScopedTypeVariables #-}
+
 module Main where
 
+import Network.Wai
+import Network.Wai.Handler.Warp
+import Network.Wai.Handler.WebSockets
+import Servant
 import WebSocketServer
 import Types
 import Utils
 import qualified Network.WebSockets as WS
 import System.Environment
+import Data.Proxy
 
 address :: String
 address = "0.0.0.0"
 
-port :: Int
-port = 3000
-
 main = do
   filepath : _ <- getArgs
   state <- initializeState filepath
-  WS.runServer address port (application state)
+  let server :: Server API = return filepath
+  run 3000 (websocketsOr WS.defaultConnectionOptions (application state) (serve api server))
+
+type API = "filepath" :> Get '[JSON] FilePath
+api :: Proxy API
+api = Proxy
+

--- a/core/haskelldo-core.cabal
+++ b/core/haskelldo-core.cabal
@@ -28,6 +28,10 @@ executable haskelldo-core
                      , stm
                      , process
                      , ghc-mod
+                     , wai
+                     , warp
+                     , wai-websockets
+                     , servant-server
   other-modules:       WebSocketServer
                      , Types
                      , Interpreter

--- a/gui/dist/main.js
+++ b/gui/dist/main.js
@@ -110,7 +110,6 @@ function initApplication () {
     if (os.platform() == 'win32') {
       child_process.exec('taskkill /pid ' + backendProcess.pid + ' /T /F')
     }
-    electron.dialog.showMessageBox({ title: "HaskellDO quitting", message: "Remember to kill the haskelldo process"})
     mainWindow = null
   })
 

--- a/gui/dist/main.js
+++ b/gui/dist/main.js
@@ -1,4 +1,6 @@
 'use strict'
+const os = require('os')
+const child_process = require('child_process')
 const electron = require('electron')
 const React = require('react')
 const ReactDOM = require('react-dom')
@@ -76,6 +78,7 @@ function startBackend(path){
   }
   coreProcess = spawn("cd " + path + " && " + corePath + " \"" + path + separator + "Main.hs\"")
   setTimeout(function(){}, 3000)
+  return coreProcess
 }
 
 function initApplication () {
@@ -84,12 +87,13 @@ function initApplication () {
   }
 
   var filePath = openFileOrDie()
+  var backendProcess
 
   if (closeAfterConfirmationDialog())
     app.exit(-1)
 
   if (!devModeActivated()) {
-    startBackend(filePath)
+    backendProcess = startBackend(filePath)
   }
 
   const {width, height} = electron.screen.getPrimaryDisplay().workAreaSize
@@ -103,6 +107,9 @@ function initApplication () {
   })
 
   mainWindow.on('closed', function () {
+    if (os.platform() == 'win32') {
+      child_process.exec('taskkill /pid ' + backendProcess.pid + ' /T /F')
+    }
     electron.dialog.showMessageBox({ title: "HaskellDO quitting", message: "Remember to kill the haskelldo process"})
     mainWindow = null
   })


### PR DESCRIPTION
I tested this and it worked just fine, but I'd like others to check it out. I'm thinking maybe we could implement functionality like opening of projects through a servant API, though this would require another annoying change of the backend to work with mutable variables, as Kit and I have done before. I think the pain of change indicates that the backend is no longer modular in a nice way and should be majorly refactored.