### PR TITLE
Fixed backend freezing

### DIFF
--- a/core/app/Main.hs
+++ b/core/app/Main.hs
@@ -2,10 +2,6 @@
 
 module Main where
 
-import Network.Wai
-import Network.Wai.Handler.Warp
-import Network.Wai.Handler.WebSockets
-import Servant
 import WebSocketServer
 import Types
 import Utils
@@ -17,13 +13,12 @@ import Data.Proxy
 address :: String
 address = "0.0.0.0"
 
+port :: Int 
+port = 3000
+
 main = do
   filepath : _ <- getArgs
   state <- initializeState filepath
   nb <- loadNotebookFromFile filepath
-  let server :: Server API = return filepath
-  run 3000 (websocketsOr WS.defaultConnectionOptions (application filepath nb state) (serve api server))
+  WS.runServer address port (application filepath nb state)
 
-type API = "filepath" :> Get '[JSON] FilePath
-api :: Proxy API
-api = Proxy

--- a/core/app/Utils.hs
+++ b/core/app/Utils.hs
@@ -12,7 +12,6 @@ import Types
 import System.FilePath
 import System.Directory
 import System.Process
-import Data.IORef
 import Language.Haskell.GhcMod
 import Language.Haskell.GhcMod.Types
 import qualified Data.Text as T

--- a/core/haskelldo-core.cabal
+++ b/core/haskelldo-core.cabal
@@ -30,10 +30,6 @@ executable haskelldo-core
                      , stm
                      , process
                      , ghc-mod
-                     , wai
-                     , warp
-                     , wai-websockets
-                     , servant-server
                      , directory
   other-modules:       WebSocketServer
                      , Types


### PR DESCRIPTION
The servant websockets library we were using was the cause of the freezing issue. I reverted back to our old server method until we can find a better replacement. This should remedy any freezing issues, I left HaskellDO running for an hour and came back to it and it worked like a charm.