### PR TITLE
fix to main.js

### DIFF
--- a/gui/dist/main.js
+++ b/gui/dist/main.js
@@ -82,7 +82,7 @@ function startBackend(path){
   if (rModeActivated()) {
     flags += " -r"
   }
-  coreProcess = spawn(`cd ${dirpath} && ${corePath} \" ${path}${flags}`); //cd into directory and then load file
+  coreProcess = spawn(`cd ${dirpath} && ${corePath} "${path}${flags}`); //cd into directory and then load file
   setTimeout(function(){}, 3000);
   return coreProcess;
 }


### PR DESCRIPTION
Fixes small issue in `dist/main.js`. Without change, HaskellDO doesn't launch - it doesn't spawn the backend.