### PR TITLE
(57) Build.hs file should utilize global stack values where possible

### DIFF
--- a/Build.hs
+++ b/Build.hs
@@ -53,7 +53,7 @@ buildGUI pdir =
     else do
       echo "Building GUI"
       shell "mkdir -p static" ""
-      Just directory <- fold (inshell "stack path --stack-yaml=client-stack.yaml --local-install-root" Turtle.empty) Foldl.head
+      Just directory <- fold (inshell ("stack path --stack-yaml=" <> clientStackYaml <> " --local-install-root") Turtle.empty) Foldl.head
       exitCode <- shell ("stack build --stack-yaml=" <> clientStackYaml) ""
       when (exitCode /= ExitSuccess) (error "GUI: Build failed")
       shell "rm -rf static/out.jsexe/*.js" ""


### PR DESCRIPTION
Enforces Utilization of clientStackYaml as per other areas of the
Build.hs file in order to maintain a consistent way to reference
these files.

Testing was done per `stack clean` into a new `stack Build.hs -a` and another clean followed with `stack Build.hs -g`

From issue #57 