### PR TITLE
Fix website links in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![Gitter](https://badges.gitter.im/theam/haskell-do.svg)](https://gitter.im/theam/haskell-do?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Build Status](https://travis-ci.org/theam/haskell-do.svg?branch=develop)](https://travis-ci.org/theam/haskell-do)
 
-[haskell.do](haskell.do) is a Haskell code editor, centered around interactive development. You can get it on [the website](haskell.do).
+[haskell.do](http://haskell.do) is a Haskell code editor, centered around interactive development. You can get it on [the website](http://haskell.do).
 
 Pull Requests are greatly appreciated, check out [our contributing guidelines](CONTRIBUTING.md).
 
 ## Building from source
 
-The only *3rd-party* requirements to build [haskell.do](haskell.do) are [Stack](http://haskellstack.org/) and [NodeJS](https://nodejs.org/) (due to GHCJS).
+The only *3rd-party* requirements to build [haskell.do](http://haskell.do) are [Stack](http://haskellstack.org/) and [NodeJS](https://nodejs.org/) (due to GHCJS).
 
 `git clone https://github.com/theam/haskell-do && cd haskell-do`
 
@@ -17,7 +17,7 @@ The only *3rd-party* requirements to build [haskell.do](haskell.do) are [Stack](
 
 `stack Build.hs -a` for building project.
 
-`stack Build.hs -r` for running [haskell.do](haskell.do) on port `8080`.
+`stack Build.hs -r` for running [haskell.do](http://haskell.do) on port `8080`.
 
 ## Contributing
 


### PR DESCRIPTION
The links were relative to the repo and were not working as supposed.