### PR TITLE
(59) feature: file explorer for "Open Project" dialog

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -21,6 +21,7 @@ dependencies:
   - text == 1.2.2.1
   - process
   - directory
+  - filepath
 
 ghc-options:
   - -Wall

--- a/src/common/HaskellDo/Compilation/State.hs
+++ b/src/common/HaskellDo/Compilation/State.hs
@@ -48,13 +48,6 @@ update (WriteWorkingFile content) state = localIO $ do
 update Compile state = do
     localIO $ writeFile lastProjectFile $ projectPath state
     compile state
-update GetLastProject state = do
-    exists <- localIO $ doesFileExist lastProjectFile
-    localIO $ unless exists (writeFile lastProjectFile "")
-    pr <- localIO $ readFile lastProjectFile
-    return state { projectPath = pr }
-
-
 
 writeWorkingFile :: String -> State -> IO ()
 writeWorkingFile content state = do

--- a/src/common/HaskellDo/Compilation/Types.hs
+++ b/src/common/HaskellDo/Compilation/Types.hs
@@ -25,5 +25,4 @@ data State = State
 data Action
     = Compile
     | WriteWorkingFile String
-    | GetLastProject
     deriving (Read, Show)

--- a/src/common/HaskellDo/Compilation/View.hs
+++ b/src/common/HaskellDo/Compilation/View.hs
@@ -40,6 +40,6 @@ errorDisplay state
 
 updateDisplays :: State -> Widget ()
 updateDisplays state = do
-  _ <- Ulmus.newWidget "outputDisplay" (outputDisplay state)
-  _ <- Ulmus.newWidget "errorDisplay" (errorDisplay state)
+  Ulmus.newWidget "outputDisplay" (outputDisplay state)
+  Ulmus.newWidget "errorDisplay" (errorDisplay state)
   liftIO highlightCode

--- a/src/common/HaskellDo/Compilation/View.hs
+++ b/src/common/HaskellDo/Compilation/View.hs
@@ -21,7 +21,6 @@ import           Prelude                     hiding (div, id)
 import           AxiomUtils
 import           Foreign.Highlight
 import           GHCJS.HPlay.View            hiding (atr)
-import           Transient.Base
 import qualified Ulmus
 
 import           HaskellDo.Compilation.Types
@@ -39,8 +38,8 @@ errorDisplay state
         ! atr "role" "alert"
         $ compilationError state
 
-updateDisplays :: State -> TransIO ()
+updateDisplays :: State -> Widget ()
 updateDisplays state = do
-  Ulmus.updateWidget "outputDisplay" (outputDisplay state)
-  Ulmus.updateWidget "errorDisplay" (errorDisplay state)
+  _ <- Ulmus.newWidget "outputDisplay" (outputDisplay state)
+  _ <- Ulmus.newWidget "errorDisplay" (errorDisplay state)
   liftIO highlightCode

--- a/src/common/HaskellDo/State.hs
+++ b/src/common/HaskellDo/State.hs
@@ -131,11 +131,8 @@ update (ToolbarAction Toolbar.SavePackage) appState = do
     return newState
 
 update (ToolbarAction action) appState = do
+    newToolbarState <- Toolbar.update action (toolbarState appState)
     let cs = compilationState appState
-    cs' <- atRemote $ Compilation.update Compilation.GetLastProject cs
-    let ts = toolbarState appState
-    let ts' = ts { Toolbar.projectPath = Compilation.projectPath cs' }
-    newToolbarState <- Toolbar.update action ts'
     let newCompilationState = cs
             { Compilation.projectPath = Toolbar.projectPath newToolbarState
             }

--- a/src/common/HaskellDo/State.hs
+++ b/src/common/HaskellDo/State.hs
@@ -21,6 +21,8 @@ import Control.Monad (when)
 
 import Transient.Move
 
+import System.FilePath ((</>))
+
 import HaskellDo.Types
 import qualified HaskellDo.SimpleMDE.State as SimpleMDE
 import qualified HaskellDo.SimpleMDE.Types as SimpleMDE
@@ -113,7 +115,7 @@ update (ToolbarAction Toolbar.LoadProject) appState = do
 
 update (ToolbarAction Toolbar.LoadPackageYaml) appState = do
     let projectPath = Compilation.projectPath (compilationState appState)
-    contents <- atRemote $ localIO $ readFile (projectPath ++ "package.yaml")
+    contents <- atRemote $ localIO $ readFile (projectPath </> "package.yaml")
     let tbState = toolbarState appState
     let tbState' = tbState { Toolbar.projectConfig = contents }
     localIO $ JQuery.setValueForId "#packageTextArea event textArea" contents
@@ -123,7 +125,7 @@ update (ToolbarAction Toolbar.LoadPackageYaml) appState = do
 update (ToolbarAction Toolbar.SavePackage) appState = do
     let projectPath = Compilation.projectPath (compilationState appState)
     let tbState = toolbarState appState
-    atRemote $ localIO $ writeFile (projectPath ++ "package.yaml") (Toolbar.projectConfig tbState)
+    atRemote $ localIO $ writeFile (projectPath </> "package.yaml") (Toolbar.projectConfig tbState)
     _ <- Toolbar.update Toolbar.ClosePackageModal tbState
     localIO $ JQuery.show "#dependencyMessage"
     newState <- update (ToolbarAction Toolbar.Compile) appState

--- a/src/common/HaskellDo/Style/View.hs
+++ b/src/common/HaskellDo/Style/View.hs
@@ -76,3 +76,5 @@ mdeStyle = Text.unpack . Clay.render $ do
         height (pct 100)
     "#dependencyMessage" ? do
         margin (px 0) auto (px 0) auto
+    "#fsTree .collection-item span" ? do
+        marginLeft (px 5)

--- a/src/common/HaskellDo/Toolbar/FileSystemTree.hs
+++ b/src/common/HaskellDo/Toolbar/FileSystemTree.hs
@@ -1,0 +1,59 @@
+{-
+ - Copyright (c) 2017 The Agile Monkeys S.L. <hackers@theam.io>
+ -
+ - Licensed under the Apache License, Version 2.0 (the "License");
+ - you may not use this file except in compliance with the License.
+ - You may obtain a copy of the License at
+ -
+ -     http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -}
+module HaskellDo.Toolbar.FileSystemTree where
+
+import Prelude hiding (div, id, span)
+
+import GHCJS.HPlay.View hiding (addHeader, atr, id, wlink)
+import AxiomUtils
+import qualified Ulmus
+
+import System.FilePath ((</>), takeDirectory, dropTrailingPathSeparator)
+
+import HaskellDo.Toolbar.Types
+
+widget :: State -> Widget Action
+widget state = Ulmus.newWidget "fsTree" $
+    if directoryExists state
+    then
+      let dirElements = map directoryItem directories
+          fileElements = map fileItem files
+
+          elements = dirElements ++ fileElements
+          final = if projectPath state /= "/"
+                  then
+                    backItem : elements
+                  else
+                    elements
+      
+      in foldl1 (<|>) final
+    else
+      noWidget
+  where
+    (directories, files) = directoryList state
+    pp = projectPath state
+
+    folderIcon = i ! atr "class" "material-icons amber-text text-darken-1" $ ("folder" :: String)
+    fileIcon = i ! atr "class" "material-icons blue-grey-text text-lighten-2" $ ("insert_drive_file" :: String)
+    backIcon = i ! atr "class" "material-icons amber-text text-lighten-1" $ ("arrow_back" :: String)
+
+    parentDirectory = takeDirectory . dropTrailingPathSeparator
+
+    item path icon name = wlink (NewPath path) (li ! atr "class" "valign-wrapper" $ icon >> span name) ! atr "class" "collection-item"
+
+    directoryItem name = item (pp </> name) folderIcon name
+    fileItem = item pp fileIcon
+    backItem = item (parentDirectory pp) backIcon ("Back" :: String)

--- a/src/common/HaskellDo/Toolbar/FileSystemTree.hs
+++ b/src/common/HaskellDo/Toolbar/FileSystemTree.hs
@@ -13,7 +13,7 @@
  - See the License for the specific language governing permissions and
  - limitations under the License.
  -}
-module HaskellDo.Toolbar.FileSystemTree where
+module HaskellDo.Toolbar.FileSystemTree (widget) where
 
 import Prelude hiding (div, id, span)
 
@@ -53,10 +53,12 @@ widget state = Ulmus.newWidget "fsTree" $
     fileIcon = i ! atr "class" "material-icons blue-grey-text text-lighten-2" $ ("insert_drive_file" :: String)
     backIcon = i ! atr "class" "material-icons amber-text text-lighten-1" $ ("arrow_back" :: String)
 
-    parentDirectory = takeDirectory . dropTrailingPathSeparator
-
-    item path icon name = wlink (NewPath path) (li ! atr "class" "valign-wrapper" $ icon >> span name) ! atr "class" "collection-item"
-
     directoryItem name = item (pp </> name) folderIcon name
     fileItem = item pp fileIcon
     backItem = item (parentDirectory pp) backIcon ("Back" :: String)
+
+parentDirectory :: FilePath -> FilePath
+parentDirectory = takeDirectory . dropTrailingPathSeparator
+
+item :: FilePath -> Perch -> String -> Widget Action
+item path icon name = wlink (NewPath path) (li ! atr "class" "valign-wrapper" $ icon >> span name) ! atr "class" "collection-item"

--- a/src/common/HaskellDo/Toolbar/FileSystemTree.hs
+++ b/src/common/HaskellDo/Toolbar/FileSystemTree.hs
@@ -27,21 +27,24 @@ import HaskellDo.Toolbar.Types
 
 widget :: State -> Widget Action
 widget state = Ulmus.newWidget "fsTree" $
-    if directoryExists state
-    then
-      let dirElements = map directoryItem directories
-          fileElements = map fileItem files
-
-          elements = dirElements ++ fileElements
-          final = if projectPath state /= "/"
-                  then
-                    backItem : elements
-                  else
-                    elements
-      
-      in foldl1 (<|>) final
+    if null pp then
+      return $ NewPath ""
     else
-      noWidget
+      if directoryExists state
+      then
+        let dirElements = map directoryItem directories
+            fileElements = map fileItem files
+
+            elements = dirElements ++ fileElements
+            final = if projectPath state /= "/"
+                    then
+                      backItem : elements
+                    else
+                      elements
+        
+        in foldl1 (<|>) final
+      else
+        noWidget
   where
     (directories, files) = directoryList state
     pp = projectPath state

--- a/src/common/HaskellDo/Toolbar/Types.hs
+++ b/src/common/HaskellDo/Toolbar/Types.hs
@@ -16,11 +16,13 @@
 module HaskellDo.Toolbar.Types where
 
 data State = State
-    { projectPath   :: String
-    , lastProject   :: String
-    , projectConfig :: String
-    , projectOpened :: Bool
-    , createProject :: Bool
+    { projectPath     :: String
+    , lastProject     :: String
+    , projectConfig   :: String
+    , projectOpened   :: Bool
+    , createProject   :: Bool
+    , directoryExists :: Bool
+    , directoryList   :: ([String], [String]) -- (directories, files)
     } deriving (Read, Show)
 
 data Action

--- a/src/common/HaskellDo/Toolbar/View.hs
+++ b/src/common/HaskellDo/Toolbar/View.hs
@@ -15,16 +15,15 @@
  -}
 module HaskellDo.Toolbar.View where
 
-
 import Prelude hiding (div, id, span)
 
 import GHCJS.HPlay.View hiding (addHeader, atr, id, wlink)
 import AxiomUtils
 import qualified Ulmus
 
-import Control.Monad.IO.Class
+import qualified HaskellDo.Toolbar.FileSystemTree as FileSystemTree
 
-import System.FilePath ((</>), takeDirectory, dropTrailingPathSeparator)
+import Control.Monad.IO.Class
 
 import HaskellDo.Toolbar.Types
 import Foreign.JQuery
@@ -110,39 +109,6 @@ pathInput state = Ulmus.newWidget "pathInput" $ do
     projPath <- liftIO $ getValueFromId "#pathInput event input"
     return $ NewPath projPath
 
-fsTree :: State -> Widget Action
-fsTree state = Ulmus.newWidget "fsTree" $
-    if directoryExists state
-    then
-      let dirElements = map directoryItem directories
-          fileElements = map fileItem files
-
-          elements = dirElements ++ fileElements
-          final = if projectPath state /= "/"
-                  then
-                    backItem : elements
-                  else
-                    elements
-      
-      in foldl1 (<|>) final
-    else
-      noWidget
-  where
-    (directories, files) = directoryList state
-    pp = projectPath state
-
-    folderIcon = i ! atr "class" "material-icons amber-text text-darken-1" $ ("folder" :: String)
-    fileIcon = i ! atr "class" "material-icons blue-grey-text text-lighten-2" $ ("insert_drive_file" :: String)
-    backIcon = i ! atr "class" "material-icons amber-text text-lighten-1" $ ("arrow_back" :: String)
-
-    parentDirectory = takeDirectory . dropTrailingPathSeparator
-
-    item path icon name = wlink (NewPath path) (li ! atr "class" "valign-wrapper" $ icon >> span name) ! atr "class" "collection-item"
-
-    directoryItem name = item (pp </> name) folderIcon name
-    fileItem = item pp fileIcon
-    backItem = item (parentDirectory pp) backIcon ("Back" :: String)
-
 packageTextArea :: State -> Widget Action
 packageTextArea _ = Ulmus.newWidget "packageTextArea" $ do
      _ <- getMultilineText "" ! atr "rows" "20" `fire` OnKeyUp
@@ -154,4 +120,4 @@ creationDisplay _ = Ulmus.newWidget "creationDisplay" $
     rawHtml $ p ! atr "class" "red-text" $ ("" :: String)
 
 updateDisplays :: State -> Widget Action
-updateDisplays = fsTree
+updateDisplays = FileSystemTree.widget

--- a/src/common/HaskellDo/Toolbar/View.hs
+++ b/src/common/HaskellDo/Toolbar/View.hs
@@ -15,7 +15,7 @@
  -}
 module HaskellDo.Toolbar.View where
 
-import Prelude hiding (div, id, span)
+import Prelude hiding (div, id)
 
 import GHCJS.HPlay.View hiding (addHeader, atr, id, wlink)
 import AxiomUtils

--- a/src/common/HaskellDo/View.hs
+++ b/src/common/HaskellDo/View.hs
@@ -18,7 +18,6 @@ module HaskellDo.View where
 
 import Prelude hiding (id, div)
 
-import Transient.Base
 import GHCJS.HPlay.View
 import qualified Ulmus
 
@@ -70,6 +69,7 @@ widgets state = do
     <|> closeModalButtonWidget
     <|> closePackageEditorButtonWidget
     <|> cancelPackageEditorButtonWidget
+    <|> fsTreeWidget
   where
     simpleMDEWidget = Ulmus.newWidget "editor" $
         Ulmus.mapAction SimpleMDEAction $
@@ -90,6 +90,9 @@ widgets state = do
     packageTextAreaWidget = Ulmus.mapAction ToolbarAction $
         Toolbar.packageTextArea (toolbarState state)
 
+    fsTreeWidget = Ulmus.mapAction ToolbarAction $
+        Toolbar.fsTree (toolbarState state)
+
     closeModalButtonWidget = Ulmus.mapAction ToolbarAction $
         Toolbar.closeModalButton (toolbarState state)
 
@@ -105,6 +108,8 @@ showDisplays state = do
     Ulmus.newWidget "outputDisplay" $ Compilation.outputDisplay (compilationState state)
     Ulmus.newWidget "errorDisplay" $ Compilation.errorDisplay (compilationState state)
 
-updateDisplays :: AppState -> TransIO ()
-updateDisplays state =
+updateDisplays :: AppState -> Widget Action
+updateDisplays state = do
     Compilation.updateDisplays (compilationState state)
+    Ulmus.mapAction ToolbarAction $
+      Toolbar.updateDisplays (toolbarState state)

--- a/src/common/HaskellDo/View.hs
+++ b/src/common/HaskellDo/View.hs
@@ -26,6 +26,7 @@ import qualified HaskellDo.Materialize.View as Materialize
 import qualified HaskellDo.SimpleMDE.View as SimpleMDE
 import qualified HaskellDo.Compilation.View as Compilation
 import qualified HaskellDo.Toolbar.View as Toolbar
+import qualified HaskellDo.Toolbar.FileSystemTree as FileSystemTree
 
 view :: AppState -> Widget Action
 view appState = Ulmus.withWidgets (widgets appState) $
@@ -91,7 +92,7 @@ widgets state = do
         Toolbar.packageTextArea (toolbarState state)
 
     fsTreeWidget = Ulmus.mapAction ToolbarAction $
-        Toolbar.fsTree (toolbarState state)
+        FileSystemTree.widget (toolbarState state)
 
     closeModalButtonWidget = Ulmus.mapAction ToolbarAction $
         Toolbar.closeModalButton (toolbarState state)

--- a/src/common/Ulmus.hs
+++ b/src/common/Ulmus.hs
@@ -26,14 +26,14 @@ import Transient.Move
 
 import AxiomUtils
 
-type Update action appState  = action -> appState -> Cloud appState
-type View action appState    = appState -> Widget action
-type UpdateDisplays appState = appState -> TransIO ()
+type Update action appState         = action -> appState -> Cloud appState
+type View action appState           = appState -> Widget action
+type UpdateDisplays action appState = appState -> Widget action
 
 data AppConfig action appState = AppConfig
   { _update         :: Update action appState
   , _view           :: View action appState
-  , _updateDisplays :: UpdateDisplays appState
+  , _updateDisplays :: UpdateDisplays action appState
   , _initialState   :: appState
   , _port           :: Integer
   , _setup          :: IO ()
@@ -46,29 +46,22 @@ initializeApp :: (Show appState, Show action, Read appState, Read action, Typeab
 initializeApp (AppConfig update view updateDisplays initialAppState appPort setup) = do
     setup
     simpleWebApp appPort $ do
-        currentState <- local $ getState initialAppState
-        nextAction <- local (render $ view currentState)
-        currentState' <- local $ getState initialAppState
-        newState <- update nextAction currentState'
-        local (setState newState)
-        renderDisplay initialAppState updateDisplays
-
+        step view
+        loop (step updateDisplays)
+  where
+    step f = do
+      currentState <- local $ getState initialAppState
+      nextAction <- local (render $ f currentState)
+      currentState' <- local $ getState initialAppState
+      newState <- update nextAction currentState'
+      local (setState newState)
+    loop f = f >> loop f
 
 widgetPlaceholder :: String -> Perch
 widgetPlaceholder id' =
   div
     ! id id'
     $ noHtml
-
-
-renderDisplay :: (Show appState, Read appState, Typeable appState)
-              => appState
-              -> UpdateDisplays appState
-              -> Cloud ()
-renderDisplay initialAppState f = do
-  state <- local $ getState initialAppState
-  local $ f state
-
 
 updateWidget :: String -> Widget () -> TransIO ()
 updateWidget s f = render $ at ("#" ++ s) Insert f

--- a/src/ghcjs-specific/Foreign/Highlight.hs
+++ b/src/ghcjs-specific/Foreign/Highlight.hs
@@ -15,5 +15,5 @@
  -}
 module Foreign.Highlight where
 
-foreign import javascript unsafe "$('.haskell').each(function(i, block){ hljs.highlightBlock(block);});"
+foreign import javascript unsafe "setTimeout(function() {$('.haskell').each(function(i, block){ hljs.highlightBlock(block);}) }, 0);"
     highlightCode :: IO ()


### PR DESCRIPTION
This pull-request adds a file explorer to the "Open Project" dialog
which allows the users to navigate through their filesystem just like a
file manager, instead of being required to enter the absolute path.
The explorer's path is synced with the input's path, so they both work
at the same time.

[📹  Quick demo](http://theread.me/fstree.mp4)