### PR TITLE
(77) Rename SimpleMDE into CodeMirror

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -48,14 +48,14 @@ library:
     - Foreign.Highlight
     - Foreign.JQuery
     - Foreign.Materialize
-    - Foreign.SimpleMDE
+    - Foreign.CodeMirror
     - HaskellDo.Compilation.State
     - HaskellDo.Compilation.Types
     - HaskellDo.Compilation.View
     - HaskellDo.Materialize.View
-    - HaskellDo.SimpleMDE.State
-    - HaskellDo.SimpleMDE.Types
-    - HaskellDo.SimpleMDE.View
+    - HaskellDo.CodeMirror.State
+    - HaskellDo.CodeMirror.Types
+    - HaskellDo.CodeMirror.View
     - HaskellDo.State
     - HaskellDo.Style.View
     - HaskellDo.Toolbar.State
@@ -74,14 +74,14 @@ executables:
       - Foreign.Highlight
       - Foreign.JQuery
       - Foreign.Materialize
-      - Foreign.SimpleMDE
+      - Foreign.CodeMirror
       - HaskellDo.Compilation.State
       - HaskellDo.Compilation.Types
       - HaskellDo.Compilation.View
       - HaskellDo.Materialize.View
-      - HaskellDo.SimpleMDE.State
-      - HaskellDo.SimpleMDE.Types
-      - HaskellDo.SimpleMDE.View
+      - HaskellDo.CodeMirror.State
+      - HaskellDo.CodeMirror.Types
+      - HaskellDo.CodeMirror.View
       - HaskellDo.State
       - HaskellDo.Style.View
       - HaskellDo.Toolbar.State

--- a/src/common/HaskellDo.hs
+++ b/src/common/HaskellDo.hs
@@ -21,12 +21,12 @@ import qualified Ulmus
 
 import HaskellDo.View
 import HaskellDo.State
-import qualified HaskellDo.SimpleMDE.View as SimpleMDE
+import qualified HaskellDo.CodeMirror.View as CodeMirror
 import qualified HaskellDo.Style.View as Style
 
 initializeHeaders :: IO ()
 initializeHeaders = do
-    SimpleMDE.initialize
+    CodeMirror.initialize
     Style.initialize
 
 -- | Executes Haskell.do in designated 'port'

--- a/src/common/HaskellDo/CodeMirror/State.hs
+++ b/src/common/HaskellDo/CodeMirror/State.hs
@@ -13,12 +13,16 @@
  - See the License for the specific language governing permissions and
  - limitations under the License.
  -}
-module HaskellDo.SimpleMDE.Types where
+module HaskellDo.CodeMirror.State where
 
-data Action
-    = NewContent String
-    deriving (Read, Show)
+import Transient.Move
+import HaskellDo.CodeMirror.Types
 
-data State = State
-    { content :: String
-    } deriving (Read, Show)
+initialState :: State
+initialState = State
+    { content = ""
+    }
+
+update :: Action -> State -> Cloud State
+update (NewContent newContent) state = do
+    return (state { content = newContent } )

--- a/src/common/HaskellDo/CodeMirror/Types.hs
+++ b/src/common/HaskellDo/CodeMirror/Types.hs
@@ -13,16 +13,12 @@
  - See the License for the specific language governing permissions and
  - limitations under the License.
  -}
-module HaskellDo.SimpleMDE.State where
+module HaskellDo.CodeMirror.Types where
 
-import Transient.Move
-import HaskellDo.SimpleMDE.Types
+data Action
+    = NewContent String
+    deriving (Read, Show)
 
-initialState :: State
-initialState = State
-    { content = ""
-    }
-
-update :: Action -> State -> Cloud State
-update (NewContent newContent) state = do
-    return (state { content = newContent } )
+data State = State
+    { content :: String
+    } deriving (Read, Show)

--- a/src/common/HaskellDo/CodeMirror/View.hs
+++ b/src/common/HaskellDo/CodeMirror/View.hs
@@ -29,7 +29,7 @@ initialize = do
     addHeader $ do
         link ! atr "rel" "stylesheet"
              ! href "https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css"
-        script ("var simpleMDE;" :: String)
+        script ("var codeMirror;" :: String)
         script ! src "https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"
                $ noHtml
     makeCodeMirrorFromId "mainEditor"

--- a/src/common/HaskellDo/CodeMirror/View.hs
+++ b/src/common/HaskellDo/CodeMirror/View.hs
@@ -13,7 +13,7 @@
  - See the License for the specific language governing permissions and
  - limitations under the License.
  -}
-module HaskellDo.SimpleMDE.View where
+module HaskellDo.CodeMirror.View where
 
 import Prelude hiding (div, id)
 import Control.Monad.IO.Class
@@ -21,8 +21,8 @@ import Control.Monad.IO.Class
 import GHCJS.HPlay.View hiding (addHeader, atr, id)
 import AxiomUtils
 
-import HaskellDo.SimpleMDE.Types
-import Foreign.SimpleMDE
+import HaskellDo.CodeMirror.Types
+import Foreign.CodeMirror
 
 initialize :: IO ()
 initialize = do
@@ -32,7 +32,7 @@ initialize = do
         script ("var simpleMDE;" :: String)
         script ! src "https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"
                $ noHtml
-    makeSimpleMDEFromId "mainEditor"
+    makeCodeMirrorFromId "mainEditor"
 
 view :: State -> Widget Action
 view _ = do

--- a/src/common/HaskellDo/State.hs
+++ b/src/common/HaskellDo/State.hs
@@ -35,21 +35,21 @@ import qualified Foreign.JQuery as JQuery
 
 initialAppState :: AppState
 initialAppState = AppState
-  { simpleMDEState = CodeMirror.initialState
+  { codeMirrorState = CodeMirror.initialState
   , compilationState = Compilation.initialState
   , toolbarState = Toolbar.initialState
   }
 
 update :: Action -> AppState -> Cloud AppState
 update (CodeMirrorAction action) appState = do
-    newCodeMirrorState <- CodeMirror.update action (simpleMDEState appState)
+    newCodeMirrorState <- CodeMirror.update action (codeMirrorState appState)
     let newContent = CodeMirror.content newCodeMirrorState
     _ <- atRemote $ Compilation.update
         (Compilation.WriteWorkingFile newContent)
         (compilationState appState)
     compileShortcutPressed <- localIO CodeMirror.cmdOrCtrlReturnPressed
     let newState = appState
-            { simpleMDEState = newCodeMirrorState
+            { codeMirrorState = newCodeMirrorState
             }
     if compileShortcutPressed
         then update (ToolbarAction Toolbar.Compile) newState
@@ -94,7 +94,7 @@ update (ToolbarAction Toolbar.LoadProject) appState = do
                 , compilationState = newCmpState
                 }
         Right contents -> do
-            let editorState = simpleMDEState appState
+            let editorState = codeMirrorState appState
             let parsedContents = unlines . drop 4 $ lines contents
             let newEditorState = editorState { CodeMirror.content = parsedContents }
             let newTbState = tbState { Toolbar.projectOpened = True }
@@ -103,7 +103,7 @@ update (ToolbarAction Toolbar.LoadProject) appState = do
             localIO $ JQuery.hide "#errorDisplay" -- Hide error while dependencies load
             localIO $ JQuery.setHtmlForId "#outputDisplay" ""
             let stateAfterOpening =  appState
-                        { simpleMDEState = newEditorState
+                        { codeMirrorState = newEditorState
                         , toolbarState = newTbState
                         , compilationState = newCmpState
                         }

--- a/src/common/HaskellDo/Types.hs
+++ b/src/common/HaskellDo/Types.hs
@@ -15,18 +15,18 @@
  -}
 module HaskellDo.Types where
 
-import qualified HaskellDo.SimpleMDE.Types as SimpleMDE
+import qualified HaskellDo.CodeMirror.Types as CodeMirror
 import qualified HaskellDo.Compilation.Types as Compilation
 import qualified HaskellDo.Toolbar.Types as Toolbar
 
 data AppState = AppState
-  { simpleMDEState   :: SimpleMDE.State
+  { simpleMDEState   :: CodeMirror.State
   , compilationState :: Compilation.State
   , toolbarState     :: Toolbar.State
   } deriving (Read, Show)
 
 
 data Action
-  = SimpleMDEAction SimpleMDE.Action
+  = CodeMirrorAction CodeMirror.Action
   | ToolbarAction Toolbar.Action
   deriving (Read, Show)

--- a/src/common/HaskellDo/Types.hs
+++ b/src/common/HaskellDo/Types.hs
@@ -20,7 +20,7 @@ import qualified HaskellDo.Compilation.Types as Compilation
 import qualified HaskellDo.Toolbar.Types as Toolbar
 
 data AppState = AppState
-  { simpleMDEState   :: CodeMirror.State
+  { codeMirrorState   :: CodeMirror.State
   , compilationState :: Compilation.State
   , toolbarState     :: Toolbar.State
   } deriving (Read, Show)

--- a/src/common/HaskellDo/View.hs
+++ b/src/common/HaskellDo/View.hs
@@ -61,7 +61,7 @@ widgets state = do
     Toolbar.toolbar
     Toolbar.creationDisplay (toolbarState state)
     showDisplays state
-    simpleMDEWidget
+    codeMirrorWidget
     <|> openProjectButtonWidget
     <|> packageEditorButtonWidget
     <|> compileButtonWidget
@@ -72,9 +72,9 @@ widgets state = do
     <|> cancelPackageEditorButtonWidget
     <|> fsTreeWidget
   where
-    simpleMDEWidget = Ulmus.newWidget "editor" $
+    codeMirrorWidget = Ulmus.newWidget "editor" $
         Ulmus.mapAction CodeMirrorAction $
-            CodeMirror.view $ simpleMDEState state
+            CodeMirror.view $ codeMirrorState state
 
     openProjectButtonWidget = Ulmus.mapAction ToolbarAction $
         Toolbar.openProjectButton (toolbarState state)

--- a/src/common/HaskellDo/View.hs
+++ b/src/common/HaskellDo/View.hs
@@ -23,7 +23,7 @@ import qualified Ulmus
 
 import HaskellDo.Types
 import qualified HaskellDo.Materialize.View as Materialize
-import qualified HaskellDo.SimpleMDE.View as SimpleMDE
+import qualified HaskellDo.CodeMirror.View as CodeMirror
 import qualified HaskellDo.Compilation.View as Compilation
 import qualified HaskellDo.Toolbar.View as Toolbar
 import qualified HaskellDo.Toolbar.FileSystemTree as FileSystemTree
@@ -73,8 +73,8 @@ widgets state = do
     <|> fsTreeWidget
   where
     simpleMDEWidget = Ulmus.newWidget "editor" $
-        Ulmus.mapAction SimpleMDEAction $
-            SimpleMDE.view $ simpleMDEState state
+        Ulmus.mapAction CodeMirrorAction $
+            CodeMirror.view $ simpleMDEState state
 
     openProjectButtonWidget = Ulmus.mapAction ToolbarAction $
         Toolbar.openProjectButton (toolbarState state)

--- a/src/ghc-specific/Foreign/CodeMirror.hs
+++ b/src/ghc-specific/Foreign/CodeMirror.hs
@@ -13,7 +13,7 @@
  - See the License for the specific language governing permissions and
  - limitations under the License.
  -}
-module Foreign.SimpleMDE where
+module Foreign.CodeMirror where
 
 getMDEContent :: IO String
 getMDEContent = return ""
@@ -21,8 +21,8 @@ getMDEContent = return ""
 setMDEContent :: String -> IO ()
 setMDEContent _ = return ()
 
-makeSimpleMDEFromId :: String -> IO ()
-makeSimpleMDEFromId _ = return ()
+makeCodeMirrorFromId :: String -> IO ()
+makeCodeMirrorFromId _ = return ()
 
 cmdOrCtrlReturnPressed :: IO Bool
 cmdOrCtrlReturnPressed = return False

--- a/src/ghcjs-specific/Foreign/CodeMirror.hs
+++ b/src/ghcjs-specific/Foreign/CodeMirror.hs
@@ -13,7 +13,7 @@
  - See the License for the specific language governing permissions and
  - limitations under the License.
  -}
-module Foreign.SimpleMDE where
+module Foreign.CodeMirror where
 
 import GHCJS.Types
 import Data.JSString
@@ -33,8 +33,8 @@ foreign import javascript unsafe "simpleMDE.setValue($1)"
 foreign import javascript unsafe "$r = cmdOrCtrlReturnPressed;"
     cmdOrCtrlReturnPressed :: IO Bool
 
-makeSimpleMDEFromId :: String -> IO ()
-makeSimpleMDEFromId = js_makeSimpleMDEFromId . pack
+makeCodeMirrorFromId :: String -> IO ()
+makeCodeMirrorFromId = js_makeCodeMirrorFromId . pack
 
 foreign import javascript unsafe
     "function initMDE() {\
@@ -55,4 +55,4 @@ foreign import javascript unsafe
     };\
     initMDE();"
 
-    js_makeSimpleMDEFromId :: JSString -> IO ()
+    js_makeCodeMirrorFromId :: JSString -> IO ()


### PR DESCRIPTION
Rename string SimpleMDE into CodeMirror.  Not only in text files but also in filenames and directories.