### PR TITLE
Re-render compilation view only if recently compiled the output

### DIFF
--- a/src/common/HaskellDo/Compilation/State.hs
+++ b/src/common/HaskellDo/Compilation/State.hs
@@ -34,6 +34,7 @@ initialState = State
     , compilationError = "No project has been loaded yet, try opening one?"
     , projectPath = ""
     , workingFile = "src/Main.hs"
+    , dirtyCompile = True
     }
 
 lastProjectFile :: FilePath
@@ -92,7 +93,7 @@ buildOutput state = do
         System.ExitFailure _ ->
             return state { compiledOutput = "Compiling" }
         System.ExitSuccess ->
-            return state { compiledOutput = preprocessOutput out, compilationError = "" }
+            return state { compiledOutput = preprocessOutput out, compilationError = "", dirtyCompile = True }
 
 
 preprocessOutput :: String -> String

--- a/src/common/HaskellDo/Compilation/Types.hs
+++ b/src/common/HaskellDo/Compilation/Types.hs
@@ -20,6 +20,7 @@ data State = State
     , compilationError :: String
     , projectPath      :: String
     , workingFile      :: String
+    , dirtyCompile     :: Bool
     } deriving (Read, Show)
 
 data Action

--- a/src/common/HaskellDo/Compilation/View.hs
+++ b/src/common/HaskellDo/Compilation/View.hs
@@ -16,7 +16,7 @@
 module HaskellDo.Compilation.View where
 
 import           Control.Monad.IO.Class
-import           Control.Monad (unless)
+import           Control.Monad (when)
 import           Prelude                     hiding (div, id)
 
 import           AxiomUtils
@@ -41,10 +41,10 @@ errorDisplay state
         $ code (compilationError state)
 
 updateDisplays :: State -> Widget ()
-updateDisplays state = do
-  highlighted <- liftIO alreadyHighlighted
-  unless highlighted $ Ulmus.newWidget "outputDisplay" (outputDisplay state)
-  Ulmus.newWidget "errorDisplay" (errorDisplay state)
-  liftIO $ activateScriptTags "#output-frame"
-  liftIO $ setHeightFromElement ".error-placeholder" "#errorDisplay"
-  liftIO highlightCode
+updateDisplays state =
+  when (dirtyCompile state) $ do
+    Ulmus.newWidget "outputDisplay" (outputDisplay state)
+    Ulmus.newWidget "errorDisplay" (errorDisplay state)
+    liftIO $ activateScriptTags "#output-frame"
+    liftIO $ setHeightFromElement ".error-placeholder" "#errorDisplay"
+    liftIO highlightCode

--- a/src/ghc-specific/Foreign/Highlight.hs
+++ b/src/ghc-specific/Foreign/Highlight.hs
@@ -17,9 +17,3 @@ module Foreign.Highlight where
 
 highlightCode :: IO ()
 highlightCode = return ()
-
-askForHighlight :: IO ()
-askForHighlight = return ()
-
-alreadyHighlighted :: IO Bool
-alreadyHighlighted = return True

--- a/src/ghcjs-specific/Foreign/Highlight.hs
+++ b/src/ghcjs-specific/Foreign/Highlight.hs
@@ -15,14 +15,5 @@
  -}
 module Foreign.Highlight where
 
-foreign import javascript unsafe "if (!alreadyHighlighted){ \
-                                    setTimeout(function() {$('.haskell').each(function(i, block){ hljs.highlightBlock(block);}) }, 0); \
-                                    alreadyHighlighted = true; \
-                                  }"
+foreign import javascript unsafe "setTimeout(function() {$('.haskell').each(function(i, block){ hljs.highlightBlock(block);}) }, 0);"
     highlightCode :: IO ()
-
-foreign import javascript unsafe "alreadyHighlighted = false;"
-    askForHighlight :: IO ()
-
-foreign import javascript unsafe "$r = alreadyHighlighted;"
-    alreadyHighlighted :: IO Bool


### PR DESCRIPTION
fix: mark `dirtyCompile` as true upon compilation, re-render Compilation view only if dirty
fix: split `update` into three parts: `preUpdate`, `update` and
`postUpdate`, this allows us to apply some pre- and post-update changes
to the state